### PR TITLE
Fix retain cycle

### DIFF
--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -122,7 +122,6 @@ static NSString *RKLogTruncateString(NSString *string)
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-static void *RKParentObjectRequestOperation = &RKParentObjectRequestOperation;
 static void *RKOperationStartDate = &RKOperationStartDate;
 static void *RKOperationFinishDate = &RKOperationFinishDate;
 
@@ -131,7 +130,6 @@ static void *RKOperationFinishDate = &RKOperationFinishDate;
     // Weakly tag the HTTP operation with its parent object request operation
     RKObjectRequestOperation *objectRequestOperation = [notification object];
     objc_setAssociatedObject(objectRequestOperation, RKOperationStartDate, [NSDate date], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(objectRequestOperation.HTTPRequestOperation, RKParentObjectRequestOperation, objectRequestOperation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     
     NSURLRequest *request = objectRequestOperation.HTTPRequestOperation.request;
     RKLogInfo(@"%@ '%@'", request.HTTPMethod, request.URL.absoluteString);

--- a/RestKit.podspec
+++ b/RestKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             =  'RestKit'
-  s.version          =  '0.26.0.cotd'
+  s.version          =  '0.26.0.cotd.0'
   s.summary          =  'RestKit is a framework for consuming and modeling RESTful web resources on iOS and OS X.'
   s.homepage         =  'https://github.com/CatchOfTheDay/RestKit'
   s.social_media_url =  'https://twitter.com/RestKit'

--- a/RestKit.podspec
+++ b/RestKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             =  'RestKit'
-  s.version          =  '0.26.0'
+  s.version          =  '0.26.0.cotd'
   s.summary          =  'RestKit is a framework for consuming and modeling RESTful web resources on iOS and OS X.'
-  s.homepage         =  'https://github.com/RestKit/RestKit'
+  s.homepage         =  'https://github.com/CatchOfTheDay/RestKit'
   s.social_media_url =  'https://twitter.com/RestKit'
   s.author           =  { 'Blake Watters' => 'blakewatters@gmail.com' }
-  s.source           =  { :git => 'https://github.com/RestKit/RestKit.git', :tag => "v#{s.version}" }
+  s.source           =  { :git => 'https://github.com/CatchOfTheDay/RestKit.git', :tag => "v#{s.version}" }
   s.license          =  'Apache License, Version 2.0'
 
   # Platform setup


### PR DESCRIPTION
The current release (v0.26.0) of RestKit with a fix (813ff40) cherry-picked from current development branch in order to fix the retain cycle introduced in c6b5d15.

The podspec has been updated to point to the Catch fork of RestKit.
